### PR TITLE
Fix opt_then_test.py for softrobo system

### DIFF
--- a/Notebooks/GettingStarted/README.md
+++ b/Notebooks/GettingStarted/README.md
@@ -11,7 +11,13 @@ To begin, you'll need to install dependencies. Besides `numpy`, `matplotlib` and
 
 
     pip install rescomp
-    pip install sherpa
+    pip install parameter-sherpa
+    
+Additionally, one of the algorithms from `sherpa` that we use depends on the `GPyOpt` library. Installing `sherpa` will install this automatically, but the version that pip will install by default has a major bug that results in the algorithm throwing an error. This can be circumvented by installing `GPyOpt` directly from its GitHub repository; this version has the error fixed:
+
+    pip install git+https://github.com/SheffieldML/GPyOpt.git
+
+(This situation is not likely to change soon, because the `GPyOpt` package is unmaintained as of November 2020.)
     
 ## Tutorials
 

--- a/Scripts/opt_then_test.py
+++ b/Scripts/opt_then_test.py
@@ -405,7 +405,13 @@ if __name__ == "__main__":
                 r0 = rcomp.initial_condition(init_cond["u0"])
         results["lyapunov"].append(meanlyap(rcomp, pre, r0, ts))
 
-    # TODO: Save results dictionary with a unique name
-    # pkl.dump("unique_name.pkl", results)
+    # Save results dictionary with a semi-unique name.
+    #   Could add a timestamp or something for stronger uniqueness
+    results_filename = "-".join((SYSTEM, MAP_INITIAL, PREDICTION_TYPE, METHOD)) + ".pkl"
+    if "--test" in options:
+        results_filename = "TEST-" + results_filename
+    with open(DATADIR + SYSTEM + results_filename, 'wb') as file:
+        pkl.dump(results, file)
+    
     if "--test" in options:
         print("Testing ran successfully")

--- a/Scripts/opt_then_test.py
+++ b/Scripts/opt_then_test.py
@@ -42,6 +42,7 @@ import sherpa
 import pickle as pkl
 import numpy as np
 import rescomp as rc
+from scipy.io import loadmat
 
 ### Constants
 #Load from the relevant .py file
@@ -100,7 +101,7 @@ def loadprior(system):
 
 def load_robo(filename):
     """Load soft robot order"""
-    data = io.loadmat(DATADIR + filename)
+    data = loadmat(DATADIR + filename)
     t = data['t'][0]
     q = data['q']
     pref = data["pref"]
@@ -153,7 +154,7 @@ def chaos_train_test_split(system, duration=10, trainper=0.66, dt=0.01, test="co
 def train_test_data(system, trainper=0.66, test="continue"):
     """ Load train test data for a given system """
     if system == "softrobo":
-        return robo_train_test_split(duration=duration, trainper=trainper, test=test)
+        return robo_train_test_split(timesteps=DURATION[system], trainper=trainper, test=test)
     else:
         return chaos_train_test_split(system, duration=DURATION[system], trainper=trainper, dt=DT[system], test=test)
 
@@ -230,7 +231,7 @@ def build_params(opt_prms, combine=False):
     """
     if combine:
         if SYSTEM == "softrobo":
-            return {**ROBO_DEFAULTS, **opt_prms, **RES_DEFAULTS}
+            return {**opt_prms, **RES_DEFAULTS, **ROBO_DEFAULTS}
         else:
             return {**opt_prms, **RES_DEFAULTS}
             
@@ -243,7 +244,7 @@ def build_params(opt_prms, combine=False):
             resprms[k] = opt_prms[k]
     resprms = {**resprms, **RES_DEFAULTS}
     if SYSTEM == "softrobo":
-        resprms = {**ROBO_DEFAULTS, **resprms} # Updates signal_dim and adds drive_dim
+        resprms = {**resprms, **ROBO_DEFAULTS} # Updates signal_dim and adds drive_dim
     return resprms, methodprms
 
 def vpt(*args, **kwargs):

--- a/Scripts/parameters/ott_params.py
+++ b/Scripts/parameters/ott_params.py
@@ -24,7 +24,8 @@ DT = {
 DURATION = {
     "lorenz": 10,
     "rossler": 150,
-    "thomas": 1000
+    "thomas": 1000,
+    "softrobo": 25000
 }
 # Parameters to optimize in the reservoir computer
 RES_OPT_PRMS = [

--- a/Scripts/parameters/ott_test.py
+++ b/Scripts/parameters/ott_test.py
@@ -9,10 +9,10 @@ BIG_ROBO_DATA = "bellows_arm1_whitened.mat"
 SMALL_ROBO_DATA = "bellows_arm_whitened.mat"
 VPTTOL = 0.5 # Valid prediction time error tolerance
 TRAINPER = 0.66 # Percentage of the data used for training
-OPT_VPT_REPS = 5
-OPT_NTRIALS = 20
-NSAVED_ORBITS = 25
-LYAP_REPS = 10
+OPT_VPT_REPS = 3
+OPT_NTRIALS = 5
+NSAVED_ORBITS = 5
+LYAP_REPS = 5
 
 # Time Steps for chaotic systems
 DT = {
@@ -24,7 +24,8 @@ DT = {
 DURATION = {
     "lorenz": 10,
     "rossler": 40,
-    "thomas": 100
+    "thomas": 100,
+    "softrobo": 1000
 }
 # Parameters to optimize in the reservoir computer
 RES_OPT_PRMS = [
@@ -46,7 +47,7 @@ ROBO_OPT_PRMS = [
 
 # Default reservoir computer hyper parameters
 RES_DEFAULTS = {
-    "res_sz":200,
+    "res_sz":50,
     "activ_f": lambda x: 1/(1+exp(-1*x)),
     "sparse_res":True,
     "uniform_weights":True,


### PR DESCRIPTION
Some data and parameter loading issues were fixed, as well as computation of vptime and the Lyapunov exponents. Now runs crash-free, and hopefully without any non-crashing bugs.
Also make it save the final results to a pickle file.

Additionally, updated README.md in Getting Started with dependencies instructions, because for some reason I only put those in the Jupyter notebook.