### PR TITLE
Fix issue calculating norm in nrmse()

### DIFF
--- a/Scripts/opt_then_test.py
+++ b/Scripts/opt_then_test.py
@@ -188,7 +188,7 @@ def nrmse(true, pred):
         err (ndarray): Error at each time value. 1D array with m entries
     """
     sig = np.std(true, axis=0)
-    err = np.mean( (true - pred)**2 / sig, axis=0)**.5
+    err = np.linalg.norm((true-pred) / sig, axis=1, ord=2)
     return err
 
 def valid_prediction_index(err, tol):


### PR DESCRIPTION
This *should* fix the issues with calculating the valid prediction time that showed up. The other functions involved appear, as far as I could test, to be doing what they should.